### PR TITLE
[codex] Limit listusers output

### DIFF
--- a/Aashii/base/commands.py
+++ b/Aashii/base/commands.py
@@ -245,6 +245,9 @@ def unblock_user_cl(update: Update, context: CallbackContext):
 
 
 
+LIST_USERS_LIMIT = 50
+
+
 @check_is_group_command
 def list_users(update: Update, context: CallbackContext):
     """List blocked/approved/declined users."""
@@ -252,32 +255,39 @@ def list_users(update: Update, context: CallbackContext):
     category = context.args[0].lower() if context.args else "all"
 
     if category == "blocked":
-        users = database.get_users_by_blocked(True)
+        users = database.get_users_by_blocked(True, LIST_USERS_LIMIT)
         heading = Message.LIST_BLOCKED_USERS
     elif category == "approved":
-        users = database.get_users_by_decision_status("approved")
+        users = database.get_users_by_decision_status("approved", LIST_USERS_LIMIT)
         heading = Message.LIST_APPROVED_USERS
     elif category == "declined":
-        users = database.get_users_by_decision_status("declined")
+        users = database.get_users_by_decision_status("declined", LIST_USERS_LIMIT)
         heading = Message.LIST_DECLINED_USERS
     elif category == "all":
-        blocked = database.get_users_by_blocked(True)
-        approved = database.get_users_by_decision_status("approved")
-        declined = database.get_users_by_decision_status("declined")
-        lines = [Message.LIST_BLOCKED_USERS]
-        lines.extend(_format_users(blocked))
-        lines.append("")
-        lines.append(Message.LIST_APPROVED_USERS)
-        lines.extend(_format_users(approved))
-        lines.append("")
-        lines.append(Message.LIST_DECLINED_USERS)
-        lines.extend(_format_users(declined))
-        update.message.reply_html("\n".join(lines))
+        _reply_user_list(
+            update,
+            Message.LIST_BLOCKED_USERS,
+            database.get_users_by_blocked(True, LIST_USERS_LIMIT),
+        )
+        _reply_user_list(
+            update,
+            Message.LIST_APPROVED_USERS,
+            database.get_users_by_decision_status("approved", LIST_USERS_LIMIT),
+        )
+        _reply_user_list(
+            update,
+            Message.LIST_DECLINED_USERS,
+            database.get_users_by_decision_status("declined", LIST_USERS_LIMIT),
+        )
         return
     else:
         update.message.reply_html(Message.LIST_USERS_USAGE)
         return
 
+    _reply_user_list(update, heading, users)
+
+
+def _reply_user_list(update: Update, heading, users):
     lines = [heading]
     lines.extend(_format_users(users))
     update.message.reply_html("\n".join(lines))

--- a/Aashii/constants/query.py
+++ b/Aashii/constants/query.py
@@ -74,12 +74,13 @@ class Query:
     GET_USERS = "SELECT user_id FROM users;"
 
     GET_USERS_BY_BLOCKED = (
-        "SELECT user_id, username, full_name FROM users WHERE blocked = %(blocked)s ORDER BY user_id;"
+        "SELECT user_id, username, full_name FROM users "
+        "WHERE blocked = %(blocked)s ORDER BY user_id DESC LIMIT %(limit)s;"
     )
 
     GET_USERS_BY_DECISION_STATUS = (
         "SELECT user_id, username, full_name FROM users "
-        "WHERE decision_status = %(decision_status)s ORDER BY user_id;"
+        "WHERE decision_status = %(decision_status)s ORDER BY user_id DESC LIMIT %(limit)s;"
     )
 
     RESET_INVITE_LINKS = (

--- a/Aashii/utils/database.py
+++ b/Aashii/utils/database.py
@@ -189,20 +189,20 @@ class Database:
         self.connection.commit()
 
 
-    def get_users_by_blocked(self, blocked: bool):
+    def get_users_by_blocked(self, blocked: bool, limit: int):
         """Return users filtered by blocked state."""
         cur = self.connection.cursor()
-        cur.execute(Query.GET_USERS_BY_BLOCKED, {"blocked": blocked})
+        cur.execute(Query.GET_USERS_BY_BLOCKED, {"blocked": blocked, "limit": limit})
         users = [(user_id, username, full_name) for (user_id, username, full_name) in cur]
         cur.close()
         return users
 
-    def get_users_by_decision_status(self, decision_status: str):
+    def get_users_by_decision_status(self, decision_status: str, limit: int):
         """Return users filtered by decision status."""
         cur = self.connection.cursor()
         cur.execute(
             Query.GET_USERS_BY_DECISION_STATUS,
-            {"decision_status": decision_status},
+            {"decision_status": decision_status, "limit": limit},
         )
         users = [(user_id, username, full_name) for (user_id, username, full_name) in cur]
         cur.close()

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This bot is a fork of https://github.com/j-arun-mani/Aashii.
 - [Host on Oracle Cloud Always Free](docs/oracle-cloud-always-free.md)
 ## Admin moderation commands
 
-- `/listusers blocked` — list all blocked users.
-- `/listusers approved` — list users whose join requests were approved.
-- `/listusers declined` — list users whose join requests were declined.
-- `/listusers all` — print blocked, approved, and declined sections together.
+- `/listusers blocked` — list the latest 50 blocked users.
+- `/listusers approved` — list the latest 50 users whose join requests were approved.
+- `/listusers declined` — list the latest 50 users whose join requests were declined.
+- `/listusers all` — print the latest 50 blocked, approved, and declined users.
 
 > If you are upgrading an existing deployment, run `data/migrate.sql` so the `users.decision_status` column exists before using these filters.


### PR DESCRIPTION
## Summary

- Limit `/listusers blocked`, `/listusers approved`, and `/listusers declined` to the newest 50 matching users.
- Make `/listusers all` send separate capped sections for blocked, approved, and declined users.
- Update the README command descriptions to mention the latest-50 limit.

## Why

Telegram rejects very large replies with `Message is too long` when the bot has thousands of users. Capping the result set keeps the command usable for admins.

## Validation

- Ran Python syntax check for `Aashii/base/commands.py`, `Aashii/utils/database.py`, and `Aashii/constants/query.py`.